### PR TITLE
[untested] Fixing page crash

### DIFF
--- a/magic.js
+++ b/magic.js
@@ -50,7 +50,9 @@ async function load_pdf_from_url(source, passwd) {
       return true;
     }
   } catch (e) {
-    console.error(e);
+    // printing huge logs leads to a page crash
+    // only enable for debugging
+    // console.error(e);
     getStatusLabelText('PROCESSING');
     return false;
   }


### PR DESCRIPTION
At the moment loops larger than 150 times are breaking and it appears due to running out of buffer space.
